### PR TITLE
Fix Build Script

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -39,7 +39,6 @@
 	</target>
 
 	<target name="jar" depends="compile">
-		<replace file="./src/plugin.yml" token="{BUILD_VER}" value="${env.TOWNYCHAT_BUILD_VER}"/>
 		<!-- Build the jar file -->
 		<jar basedir="${build}" destfile="${env.LIB}/TownyChat.jar">
 			<fileset dir="./src" includes="changelog.txt" />


### PR DESCRIPTION
Removes an unused line in the ant build script that caused the build to fail.
The target token is missing from plugin.yml