### PR TITLE
Updated comments to reflect change with toggling chats

### DIFF
--- a/resources/Channels.yml
+++ b/resources/Channels.yml
@@ -2,10 +2,10 @@
 # The formating for them remains in the Towny Config and world files
 # so they can still be used on a per world basis.
 
-# Channels are toggleable using any of the commands listed
-# eg. /tc (would put you in town chat)
-#          doing it again would take you out
-#          So long as you had the permission node for that channel.
+# In order to swap channels, you must use the desired channel's command 
+#          to enter the new chat and leave the old one.
+# eg. /tc (would put you in town chat) and typing it again would not change 
+#          you channel. To get back to general chat, you can do /g. 
 
 # The channel type is either GLOBAL, TOWN, NATION or DEFAULT.
 #  These specify what chat formating section they will use


### PR DESCRIPTION
Adjusted comments to reflect a change where using the same chat channel command (eg /tc) repeatedly no longer toggles the chat channel. Players must swap channels via using their desired channels command (eg to leave /tc and get back to general, a player must use the command /g, rather than running /tc a second time).