### PR TITLE
Add Hex Color Support to TownyChat

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,14 +64,24 @@
             <id>placeholderapi</id>
             <url>http://repo.extendedclip.com/content/repositories/placeholderapi/</url>
         </repository>
+        <repository>
+            <id>jitpack.io</id>
+            <url>https://jitpack.io</url>
+        </repository>
     </repositories>
 
     <dependencies>
         <dependency>
-   	        <groupId>com.palmergames.bukkit.towny</groupId>
-	        <artifactId>Towny</artifactId>
-	        <version>LATEST</version>
-	        <scope>provided</scope>
+            <groupId>com.github.TownyAdvanced</groupId>
+            <artifactId>Towny</artifactId>
+            <version>0.96.2.2</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.spigotmc</groupId>
+            <artifactId>spigot-api</artifactId>
+            <version>1.16.1-R0.1-SNAPSHOT</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.bukkit</groupId>

--- a/src/com/palmergames/bukkit/TownyChat/HexFormatter.java
+++ b/src/com/palmergames/bukkit/TownyChat/HexFormatter.java
@@ -1,0 +1,23 @@
+package com.palmergames.bukkit.TownyChat;
+
+import net.md_5.bungee.api.ChatColor;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class HexFormatter {
+
+    public static final Pattern hexPattern = Pattern.compile("(?<!\\\\)(#[a-fA-F0-9]{6})");
+
+    public static String translateHexColors(String str) {
+        Matcher hexMatcher = hexPattern.matcher(str);
+
+        while (hexMatcher.find()) {
+            String hex = hexMatcher.group();
+            str = str.replace(hex, ChatColor.of(hex).toString());
+        }
+
+        return str;
+    }
+
+}

--- a/src/com/palmergames/bukkit/TownyChat/HexFormatter.java
+++ b/src/com/palmergames/bukkit/TownyChat/HexFormatter.java
@@ -8,13 +8,29 @@ import java.util.regex.Pattern;
 public class HexFormatter {
 
     public static final Pattern hexPattern = Pattern.compile("(?<!\\\\)(#[a-fA-F0-9]{6})");
+    public static final Pattern ampersandPattern = Pattern.compile("(?<!\\\\)(&#[a-fA-F0-9]{6})");
+    public static final Pattern bracketPattern = Pattern.compile("(?<!\\\\)\\{(#[a-fA-F0-9]{6})}");
 
     public static String translateHexColors(String str) {
-        Matcher hexMatcher = hexPattern.matcher(str);
+        final Matcher hexMatcher = hexPattern.matcher(str);
+        final Matcher ampMatcher = ampersandPattern.matcher(str);
+        final Matcher bracketMatcher = bracketPattern.matcher(str);
 
         while (hexMatcher.find()) {
             String hex = hexMatcher.group();
             str = str.replace(hex, ChatColor.of(hex).toString());
+        }
+
+        while (ampMatcher.find()) {
+            String hex = ampMatcher.group().replace("&", "");
+            str = str.replace(hex, ChatColor.of(hex).toString());
+            str = str.replace("&", "");
+        }
+
+        while (bracketMatcher.find()) {
+            String hex = bracketMatcher.group().replace("{", "").replace("}", "");
+            str = str.replace(hex, ChatColor.of(hex).toString());
+            str = str.replace("{", "").replace("}", "");
         }
 
         return str;

--- a/src/com/palmergames/bukkit/TownyChat/listener/TownyChatPlayerListener.java
+++ b/src/com/palmergames/bukkit/TownyChat/listener/TownyChatPlayerListener.java
@@ -1,11 +1,13 @@
 package com.palmergames.bukkit.TownyChat.listener;
 
 import com.palmergames.bukkit.TownyChat.Chat;
+import com.palmergames.bukkit.TownyChat.HexFormatter;
 import com.palmergames.bukkit.TownyChat.TownyChatFormatter;
 import com.palmergames.bukkit.TownyChat.channels.Channel;
 import com.palmergames.bukkit.TownyChat.channels.channelTypes;
 import com.palmergames.bukkit.TownyChat.config.ChatSettings;
 import com.palmergames.bukkit.TownyChat.tasks.onPlayerJoinTask;
+import com.palmergames.bukkit.towny.Towny;
 import com.palmergames.bukkit.towny.TownyMessaging;
 import com.palmergames.bukkit.towny.TownySettings;
 import com.palmergames.bukkit.towny.exceptions.NotRegisteredException;
@@ -102,8 +104,13 @@ public class TownyChatPlayerListener implements Listener  {
 			}
 		}
 		
-		if(player.hasPermission("townychat.chat.color"))
+		if(player.hasPermission("townychat.chat.color")) {
 			event.setMessage(ChatColor.translateAlternateColorCodes('&', event.getMessage()));
+
+			if (Towny.is116Plus()) {
+				event.setMessage(HexFormatter.translateHexColors(event.getMessage()));
+			}
+		}
 		
 		// Check if essentials has this player muted.
 		if (!isMuted(player)) {


### PR DESCRIPTION
The format for hex colors is a `#` symbol followed by 6 numbers. 

You can use any of the 3 formats:
`#RRGGBB`
`&#RRGGBB`
`{#RRGGBB}`

 This also updates the pom to 1.16 and uses the jitpack repo for towny now. 

Note: **This is only supported on Towny 0.96.2.2+.**