### PR TITLE
Bump towny version.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.palmergames.bukkit</groupId>
     <artifactId>TownyChat</artifactId>
     <packaging>jar</packaging>
-    <version>0.73</version>
+    <version>0.74</version>
 
     <licenses>
         <license>

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
         <dependency>
             <groupId>com.github.TownyAdvanced</groupId>
             <artifactId>Towny</artifactId>
-            <version>0.96.2.2</version>
+            <version>0.96.2.5</version>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
This prevents the `NoSuchMethodException` spam that occurs from a version mismatch.