### PR TITLE
Make exclamation point shouting optional.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.palmergames.bukkit</groupId>
     <artifactId>TownyChat</artifactId>
     <packaging>jar</packaging>
-    <version>0.102</version>
+    <version>0.103</version>
 
     <licenses>
         <license>

--- a/resources/changelog.txt
+++ b/resources/changelog.txt
@@ -439,3 +439,7 @@ v0.101:
   - Fix permission test backing /channel join {channelname}.
 v0.102:
   - Parse placeholders when we're unable to find a channel to speak into, but modify_chat is true.
+v0.103:
+  - New Config Option: allow_exclamation_point_to_shout
+    - Default: true
+    - If true players that say !somewords will have their message sent to a global type channel with unlimited range (usually your general chat.)

--- a/src/com/palmergames/bukkit/TownyChat/config/ChatConfigNodes.java
+++ b/src/com/palmergames/bukkit/TownyChat/config/ChatConfigNodes.java
@@ -167,7 +167,12 @@ public enum ChatConfigNodes {
     		"display_channel_join_message_on_joining_the_server",
     		"true",
     		"",
-    		"# If true players will see You have joined channel {channel} message on joining the server."),    
+    		"# If true players will see You have joined channel {channel} message on joining the server."),
+    ALLOW_EXCLAMATION_POINT_SHOUTS(
+    		"allow_exclamation_point_to_shout",
+    		"true",
+    		"",
+    		"# If true players that say !somewords will have their message sent to a global type channel with unlimited range (usually your general chat.)"),
     WORLDS("worlds","","");
 	
 

--- a/src/com/palmergames/bukkit/TownyChat/config/ChatSettings.java
+++ b/src/com/palmergames/bukkit/TownyChat/config/ChatSettings.java
@@ -177,6 +177,13 @@ public class ChatSettings {
 		return getBoolean(ChatConfigNodes.DISPLAY_CHANNEL_JOIN_MESSAGE_ON_JOIN);
 	}
 
+	/**
+	 * @return true if preceding exclamation points shouts into global channel with unlimited range.
+	 */
+	public static boolean isExclamationPoint() {
+		return getBoolean(ChatConfigNodes.ALLOW_EXCLAMATION_POINT_SHOUTS);
+	}
+
 	/*
 	 * Get Tags formats.
 	 */

--- a/src/com/palmergames/bukkit/TownyChat/listener/TownyChatPlayerListener.java
+++ b/src/com/palmergames/bukkit/TownyChat/listener/TownyChatPlayerListener.java
@@ -75,7 +75,7 @@ public class TownyChatPlayerListener implements Listener  {
 		// Check if essentials has this player muted.
 		if (!isEssentialsMuted(player)) {
 			
-			boolean forceGlobal = event.getMessage().startsWith("!");
+			boolean forceGlobal = ChatSettings.isExclamationPoint() && event.getMessage().startsWith("!");
 
 			/*
 			 * If this was directed chat send it via the relevant channel


### PR DESCRIPTION
- New Config Option: allow_exclamation_point_to_shout
    - Default: true
    - If true players that say !somewords will have their message sent to a global type channel with unlimited range (usually your general chat.)