### PR TITLE
Add focusable option to channels

### DIFF
--- a/resources/Channels.yml
+++ b/resources/Channels.yml
@@ -24,6 +24,11 @@
 #	  0 = same world only
 #	  any positive value = limited range in the same world.
 
+# focusable is a setting which allows players to set their focused channel, 
+# ie: using the /tc command with no message. Channels are focusable by default,
+# so there is no point to adding focusable: true. You make a channel un-focusable
+# by adding focusable: false.
+
 # Text colouring
 # --------------
 # Black = &0, Navy = &1, Green = &2, Blue = &3, Red = &4

--- a/src/com/palmergames/bukkit/TownyChat/Command/commandobjects/ChannelJoinAliasCommand.java
+++ b/src/com/palmergames/bukkit/TownyChat/Command/commandobjects/ChannelJoinAliasCommand.java
@@ -46,7 +46,8 @@ public class ChannelJoinAliasCommand extends BukkitCommand {
 						// - channel has no permission set [by default they don't] OR
 						//   - channel has permission set AND:
 						//     - player has channel permission
-						if (!channel.hasPermission(player)) {
+						// - the Channel is designated as being joinable (which they are by default.)
+						if (!channel.hasPermission(player) || !channel.isFocusable()) {
 							TownyMessaging.sendErrorMsg(player, Translatable.of("tc_err_you_cannot_join_channel", channel.getName()));
 							return true;
 						}

--- a/src/com/palmergames/bukkit/TownyChat/channels/Channel.java
+++ b/src/com/palmergames/bukkit/TownyChat/channels/Channel.java
@@ -25,6 +25,7 @@ public abstract class Channel {
 	private double range;
 	private boolean hooked=false;
 	private boolean autojoin=true;
+	private boolean focusable = true;
 	private double spamtime;
 	private WeakHashMap<Player, Long> spammers = new WeakHashMap<>();
 	protected ConcurrentMap<String, Integer> absentPlayers = null;  
@@ -261,6 +262,12 @@ public abstract class Channel {
 		return autojoin;
 	}
 
+	public boolean isFocusable() {
+		return focusable;
+	}
+	public void setFocusable(boolean focusable) {
+		this.focusable = focusable;
+	}
 	public double getSpam_time() {
 		return spamtime;
 	}

--- a/src/com/palmergames/bukkit/TownyChat/config/ChannelConfigurationHandler.java
+++ b/src/com/palmergames/bukkit/TownyChat/config/ChannelConfigurationHandler.java
@@ -107,6 +107,16 @@ public class ChannelConfigurationHandler {
 					}
 				}
 
+				if (key.equalsIgnoreCase("focusable")) {
+					if (element instanceof Boolean) {
+						channel.setFocusable((Boolean)element);
+					} else if (element instanceof String) {
+						channel.setFocusable(Boolean.parseBoolean(element.toString()));
+					} else if (element instanceof Integer) {
+						channel.setFocusable(Integer.parseInt(element.toString()) != 0);
+					}
+				}
+
 				if (key.equalsIgnoreCase("default")) {
 					boolean set = false;
 					if (element instanceof Boolean) {


### PR DESCRIPTION
Allowing servers to prevent players from focusing onto channels, ie preventing using /tc with no message.

Closes https://github.com/TownyAdvanced/Towny/issues/6650