### PR TITLE
Add optional listen and speak nodes to TownyChat channels.

### DIFF
--- a/resources/Channels.yml
+++ b/resources/Channels.yml
@@ -14,6 +14,19 @@
 
 # channeltag is applied if the chat format for that channel has the {channelTag}
 
+# permission is an optional key in a channel, when it is set the given value
+# will be the permission node required to listen/speak in the channel. It is used
+# when either spearkpermission or listenpermission is not set.
+
+# speakpermission is an optional key in a channel, when it is set the given value
+# will be the permission node required to speak in the channel.
+
+# listenpermission is an optional key in a channel, when it is set the given value
+# will be the permission node required to listen to the channel.
+
+# leavepermission is an optional key in a channel, when it is set the given value
+# will be the permission node required to listen to the channel.
+
 # messagecolour sets the colour of the message when sent.
 
 # range is a setting which allows greater control over each channel.

--- a/src/com/palmergames/bukkit/TownyChat/Command/ChannelCommand.java
+++ b/src/com/palmergames/bukkit/TownyChat/Command/ChannelCommand.java
@@ -119,7 +119,7 @@ public class ChannelCommand extends BaseCommand implements CommandExecutor {
 		TownyMessaging.sendMessage(player, ChatTools.formatTitle("Channels"));
 		TownyMessaging.sendMessage(player, Colors.Gold + "Channel" + Colors.Gray + " - " + Colors.LightBlue + translator.of("tc_channel_list_status"));
 		for (Map.Entry<String, Channel> channel : chanList.entrySet()) {
-			if (channel.getValue().hasPermission(player))
+			if (channel.getValue().hasListenPermission(player))
 				if (channel.getValue().isPresent(player.getName()))
 					TownyMessaging.sendMessage(player, Colors.Gold + channel.getKey() + Colors.Gray + " - " + Colors.LightBlue + translator.of("tc_channel_list_in"));
 				else
@@ -372,7 +372,7 @@ public class ChannelCommand extends BaseCommand implements CommandExecutor {
 		// - channel has no permission set OR  [by default they don't]
 		//   - channel has permission set AND:
 		//     - player has channel permission
-		if (!chan.hasPermission(player)) {
+		if (!chan.hasListenPermission(player)) {
 			TownyMessaging.sendErrorMsg(player, Translatable.of("tc_err_you_cannot_join_channel", chan.getName()));
 			return;
 		}

--- a/src/com/palmergames/bukkit/TownyChat/Command/commandobjects/ChannelJoinAliasCommand.java
+++ b/src/com/palmergames/bukkit/TownyChat/Command/commandobjects/ChannelJoinAliasCommand.java
@@ -47,7 +47,7 @@ public class ChannelJoinAliasCommand extends BukkitCommand {
 						//   - channel has permission set AND:
 						//     - player has channel permission
 						// - the Channel is designated as being joinable (which they are by default.)
-						if (!channel.hasPermission(player) || !channel.isFocusable()) {
+						if (!channel.hasSpeakPermission(player) || !channel.isFocusable()) {
 							TownyMessaging.sendErrorMsg(player, Translatable.of("tc_err_you_cannot_join_channel", channel.getName()));
 							return true;
 						}
@@ -67,7 +67,7 @@ public class ChannelJoinAliasCommand extends BukkitCommand {
 					// - channel has no permission set [by default they don't] OR
 					//   - channel has permission set AND:
 					//     - player has channel permission
-					if (!channel.hasPermission(player)) {
+					if (!channel.hasSpeakPermission(player)) {
 						TownyMessaging.sendErrorMsg(player, Translatable.of("tc_err_you_cannot_join_channel", channel.getName()));
 						return true;
 					}

--- a/src/com/palmergames/bukkit/TownyChat/channels/Channel.java
+++ b/src/com/palmergames/bukkit/TownyChat/channels/Channel.java
@@ -21,7 +21,7 @@ public abstract class Channel {
 	private String name;
 	private List<String> commands;
 	private channelTypes type;
-	private String channelTag, messageColour, permission, leavePermission, channelSound;
+	private String channelTag, messageColour, permission, leavePermission, channelSound, listenPermission, speakPermission;
 	private double range;
 	private boolean hooked=false;
 	private boolean autojoin=true;
@@ -237,6 +237,36 @@ public abstract class Channel {
 		leavePermission = permission;
 	}
 
+	public boolean hasListenPermission() {
+		return listenPermission != null;
+	}
+
+	/**
+	 * @return the permission node required to listen to a channel.
+	 */
+	public String getListenPermissionNode() {
+		return listenPermission;
+	}
+
+	public void setListenPermission(String permission) {
+		listenPermission = permission;
+	}
+
+	public boolean hasSpeakPermission() {
+		return speakPermission != null;
+	}
+
+	/**
+	 * @return the permission node required to speak into a channel.
+	 */
+	public String getSpeakPermissionNode() {
+		return speakPermission;
+	}
+
+	public void setSpeakPermission(String permission) {
+		speakPermission = permission;
+	}
+
 	public boolean hasMuteList() {
 		if (mutedPlayers == null || mutedPlayers.isEmpty()) return false;
 		return true;
@@ -443,5 +473,17 @@ public abstract class Channel {
 	}
 	public boolean hasPermission(Player player) {
 		return getPermission() != null && TownyUniverse.getInstance().getPermissionSource().testPermission(player, getPermission());
+	}
+
+	public boolean hasSpeakPermission(Player player) {
+		if (!hasSpeakPermission())
+			return hasPermission(player);
+		return TownyUniverse.getInstance().getPermissionSource().testPermission(player, getSpeakPermissionNode());
+	}
+
+	public boolean hasListenPermission(Player player) {
+		if (!hasListenPermission())
+			return hasPermission(player);
+		return TownyUniverse.getInstance().getPermissionSource().testPermission(player, getListenPermissionNode());
 	}
 }

--- a/src/com/palmergames/bukkit/TownyChat/channels/ChannelsHolder.java
+++ b/src/com/palmergames/bukkit/TownyChat/channels/ChannelsHolder.java
@@ -100,7 +100,7 @@ public class ChannelsHolder {
 		String name = player.getName();
 		
 		// Return the defaultChan if it is the correct type, and the player is present in that channel.
-		if (getDefaultChannel() != null && getDefaultChannel().isPresent(name) && getDefaultChannel().getType().equals(type)) {
+		if (getDefaultChannel() != null && getDefaultChannel().isPresent(name) && getDefaultChannel().getType().equals(type) && getDefaultChannel().hasSpeakPermission(player)) {
 			if (!unlimitedRange || getDefaultChannel().getRange() < 1)
 				return getDefaultChannel();
 		}
@@ -108,7 +108,7 @@ public class ChannelsHolder {
 		for (Channel channel: channels.values()) {
 			if (!channel.isPresent(name)) continue;
 			if (!channel.getType().equals(type)) continue;
-			if (channel.hasPermission(player)) {
+			if (channel.hasSpeakPermission(player)) {
 				if (channel.getRange() == -1) {
 					global = channel;
 				} else if (channel.getRange() == 0) {
@@ -146,7 +146,7 @@ public class ChannelsHolder {
 		
 		for (Channel channel: channels.values()) {
 			if (!channel.getType().equals(type)) continue;
-			if (channel.hasPermission(player)){
+			if (channel.hasSpeakPermission(player)){
 				if (channel.getRange() == -1) {
 					global = channel;
 				} else if (channel.getRange() == 0) {
@@ -178,10 +178,12 @@ public class ChannelsHolder {
 		Set<String> perms = new HashSet<String>();
 		
 		for (Channel channel: channels.values()) {
-			if (!perms.contains(channel.getPermission())) {
+			if (!perms.contains(channel.getPermission()))
 				perms.add(channel.getPermission());
-				
-			}
+			if (channel.hasListenPermission() && !perms.contains(channel.getListenPermissionNode()))
+				perms.add(channel.getListenPermissionNode());
+			if (channel.hasSpeakPermission() && !perms.contains(channel.getSpeakPermissionNode()))
+				perms.add(channel.getSpeakPermissionNode());
 		}
 		return perms;
 	}

--- a/src/com/palmergames/bukkit/TownyChat/channels/StandardChannel.java
+++ b/src/com/palmergames/bukkit/TownyChat/channels/StandardChannel.java
@@ -151,7 +151,7 @@ public class StandardChannel extends Channel {
 		// Refresh the potential channels a player can see, if they are not currently in the channel.
 		playerList.stream().forEach(p -> refreshPlayer(this, p));
 		return playerList.stream()
-				.filter(p -> hasPermission(p)) // Check permission.
+				.filter(p -> hasListenPermission(p)) // Check permission.
 				.filter(p -> testDistance(sender, p, getRange())) // Within range.
 				.filter(p -> !plugin.isIgnoredByEssentials(sender, p)) // Check essentials ignore.
 				.filter(p -> !isAbsent(p.getName())) // Check if player is purposefully absent.

--- a/src/com/palmergames/bukkit/TownyChat/config/ChannelConfigurationHandler.java
+++ b/src/com/palmergames/bukkit/TownyChat/config/ChannelConfigurationHandler.java
@@ -152,6 +152,14 @@ public class ChannelConfigurationHandler {
 					if (element instanceof String)
 						channel.setLeavePermission(element.toString());
 
+				if (key.equalsIgnoreCase("listenpermission"))
+					if (element instanceof String)
+						channel.setListenPermission(element.toString());
+
+				if (key.equalsIgnoreCase("speakpermission"))
+					if (element instanceof String)
+						channel.setSpeakPermission(element.toString());
+
 				if (key.equalsIgnoreCase("range"))
 					channel.setRange(Double.valueOf(element.toString()));
 

--- a/src/com/palmergames/bukkit/TownyChat/listener/TownyChatPlayerListener.java
+++ b/src/com/palmergames/bukkit/TownyChat/listener/TownyChatPlayerListener.java
@@ -48,7 +48,7 @@ public class TownyChatPlayerListener implements Listener  {
 		refreshPlayerChannels(player);
 
 		Channel channel = plugin.getChannelsHandler().getDefaultChannel();
-		if (channel != null &&  channel.hasPermission(player)) {
+		if (channel != null && channel.hasSpeakPermission(player)) {
 			plugin.setPlayerChannel(player, channel);
 			if (ChatSettings.getShowChannelMessageOnServerJoin())
 				TownyMessaging.sendMessage(player, Translatable.of("tc_you_are_now_talking_in_channel", channel.getName()));
@@ -100,7 +100,7 @@ public class TownyChatPlayerListener implements Listener  {
 			 * Check the player for any channel modes.
 			 */
 			Channel channel = plugin.getPlayerChannel(player);
-			if (!forceGlobal && channel != null && channel.hasPermission(player)) {
+			if (!forceGlobal && channel != null && channel.hasSpeakPermission(player)) {
 				if (isMutedOrSpam(event, channel, player))
 					return;
 				channel.chatProcess(event);


### PR DESCRIPTION
Channels.yml can now accept speakpermission and listenpermission keys in channels. When they are set the players just have the set values in order to speak/listen to a channel.

This makes it possible to create channels that can only be heard, and not spoken into.

Closes https://github.com/TownyAdvanced/Towny/issues/1020