### PR TITLE
Fix creation of channels.yml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.palmergames.bukkit</groupId>
     <artifactId>TownyChat</artifactId>
     <packaging>jar</packaging>
-    <version>0.110</version>
+    <version>0.111</version>
 
     <licenses>
         <license>

--- a/resources/changelog.txt
+++ b/resources/changelog.txt
@@ -479,3 +479,6 @@ v0.110:
   - Add CommentedConfiguration support to the channels.yml.
     - The Comments in the file have been updated to include missing channel flags.
     - It is now possible to update the file comments as new flags are added.
+v0.111:
+  - Fix creation of channels.yml, opting to make channels into proper ConfigurationSections rather than Maps which aren't easily read on their first creation and then subsequent load.
+  - It is no longer recommended to delete your channels.yml when updating from TownyChat 0.109 or earlier.

--- a/src/com/palmergames/bukkit/TownyChat/config/ChannelsSettings.java
+++ b/src/com/palmergames/bukkit/TownyChat/config/ChannelsSettings.java
@@ -37,7 +37,7 @@ public class ChannelsSettings {
 		if (FileMgmt.checkOrCreateFile(filepath)) {
 			File file = new File(filepath);
 
-			// read the config.yml into memory
+			// read the channels.yml into memory
 			channelConfig = new CommentedConfiguration(file.toPath());
 			if (!channelConfig.load()) {
 				Bukkit.getLogger().severe("[TownyChat] Failed to load Channels.yml!");
@@ -91,7 +91,6 @@ public class ChannelsSettings {
 	}
 
 	private static void tryAndSetDefaultChannels() {
-
 		if (channelConfig.contains(CHANNELS_ROOT)) {
 			// There is already a root channels present, not our first run.
 			newChannelConfig.set(CHANNELS_ROOT, channelConfig.get(CHANNELS_ROOT));
@@ -100,18 +99,21 @@ public class ChannelsSettings {
 			Chat.getTownyChat().getLogger().info("TownyChat creating default channels.yml file.");
 
 			newChannelConfig.createSection(CHANNELS_ROOT);
-			for (String channel : DEFAULT_CHANNELS)
-				newChannelConfig.createSection(CHANNELS_ROOT + "." + channel);
-	
-			ConfigurationSection configurationSection = newChannelConfig.getConfigurationSection(CHANNELS_ROOT);
-			configurationSection.set("general", generalDefaults());
-			configurationSection.set("town", townDefaults());
-			configurationSection.set("nation", nationDefaults());
-			configurationSection.set("alliance", allianceDefaults());
-			configurationSection.set("admin", adminDefaults());
-			configurationSection.set("mod", modDefaults());
-			configurationSection.set("local", localDefaults());
+			DEFAULT_CHANNELS.forEach(channel -> newChannelConfig.createSection(CHANNELS_ROOT + "." + channel));
+
+			setConfigSection("general", generalDefaults());
+			setConfigSection("town", townDefaults());
+			setConfigSection("nation", nationDefaults());
+			setConfigSection("alliance", allianceDefaults());
+			setConfigSection("admin", adminDefaults());
+			setConfigSection("mod", modDefaults());
+			setConfigSection("local", localDefaults());
 		}
+	}
+
+	private static void setConfigSection(String section, Map<String,Object> settings) {
+		ConfigurationSection configurationSection = newChannelConfig.getConfigurationSection(CHANNELS_ROOT + "." + section);
+		settings.entrySet().stream().forEach(entry -> configurationSection.set(entry.getKey(), entry.getValue()));
 	}
 
 	private static Map<String, Object> generalDefaults() {


### PR DESCRIPTION
- Fix creation of channels.yml, opting to make channels into proper ConfigurationSections rather than Maps which aren't easily read on their first creation and then subsequent load.
- It is no longer recommended to delete your channels.yml when updating from TownyChat 0.109 or earlier.