### PR TITLE
Add the ability to choose which EventPriority TownyChat uses to modify chat.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.palmergames.bukkit</groupId>
     <artifactId>TownyChat</artifactId>
     <packaging>jar</packaging>
-    <version>0.116</version>
+    <version>0.117</version>
 
     <licenses>
         <license>
@@ -26,7 +26,7 @@
         <java.version>17</java.version>
         <project.bukkitAPIVersion>1.16</project.bukkitAPIVersion>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <towny.version>0.100.3.0</towny.version>
+        <towny.version>0.100.4.0</towny.version>
     </properties>
 
     <!-- For use with GitHub Package Registry -->

--- a/resources/changelog.txt
+++ b/resources/changelog.txt
@@ -501,3 +501,14 @@ v0.116:
     - Ignoring channels is achieved by using /res toggle ignoreotherchannels. When this mode is used you will only see the channel you are present in.
     - ie: if you are in town chat, with ignoreotherchannels active, you will not see the general, nation or local chats.
     - Closes https://github.com/TownyAdvanced/Towny/issues/6441.
+0.117:
+  - Bump min Towny version to 0.100.3.0.
+  - Add the ability to choose which EventPriority TownyChat uses to modify chat.
+    - Closes https://github.com/TownyAdvanced/Towny/issues/7625.
+  - New ChatConfig.yml Option: modify_chat.listener_priority
+    - Default: normal
+    - The priority used for the AsyncPlayerChatEvent listener in TownyChat. This option will decide when TownyChat listens to the Chat event thrown by Bukkit-based servers.
+    - Valid settings are: lowest, low, normal, high, highest
+    - Lowest is the earliest listener, allowing TownyChat to act upon chat before Low, Normal, High, and Highest priority plugins.
+    - Highest will cause TownyChat to change chat after other plugins operating on lower priorities.
+    - If you don't know what any of this means leave it at normal.

--- a/src/com/palmergames/bukkit/TownyChat/Chat.java
+++ b/src/com/palmergames/bukkit/TownyChat/Chat.java
@@ -58,7 +58,7 @@ public class Chat extends JavaPlugin {
 	private DynmapAPI dynMap = null;
 	private Essentials essentials = null;
 	
-	private static String requiredTownyVersion = "0.100.3.0";
+	private static String requiredTownyVersion = "0.100.4.0";
 	public static boolean usingPlaceholderAPI = false;
 	public static boolean usingEssentialsDiscord = false;
 	boolean chatConfigError = false;

--- a/src/com/palmergames/bukkit/TownyChat/config/ChatConfigNodes.java
+++ b/src/com/palmergames/bukkit/TownyChat/config/ChatConfigNodes.java
@@ -144,6 +144,15 @@ public enum ChatConfigNodes {
 			"modify_chat",
 			"",
 			""),
+	MODIFY_CHAT_LISTENER_PRIORITY(
+			"modify_chat.listener_priority",
+			"normal",
+			"",
+			"# The priority used for the AsyncPlayerChatEvent listener in TownyChat. This option will decide when TownyChat listens to the Chat event thrown by Bukkit-based servers.",
+			"# Valid settings are: lowest, low, normal, high, highest",
+			"# Lowest is the earliest listener, allowing TownyChat to act upon chat before Low, Normal, High, and Highest priority plugins.",
+			"# Highest will cause TownyChat to change chat after other plugins operating on lower priorities.",
+			"# If you don't know what any of this means leave it at normal."),
     MODIFY_CHAT_ENABLE(
     		"modify_chat.enable",
     		"true",

--- a/src/com/palmergames/bukkit/TownyChat/config/ChatSettings.java
+++ b/src/com/palmergames/bukkit/TownyChat/config/ChatSettings.java
@@ -184,6 +184,14 @@ public class ChatSettings {
 		return getBoolean(ChatConfigNodes.ALLOW_EXCLAMATION_POINT_SHOUTS);
 	}
 
+	public static String getChatListenerPriority() {
+		String priority = getString(ChatConfigNodes.MODIFY_CHAT_LISTENER_PRIORITY).toLowerCase(Locale.ROOT);
+		return switch(priority) {
+		case "lowest","low","normal","high","highest"-> priority;
+		default -> "normal";
+		};
+	}
+
 	/*
 	 * Get Tags formats.
 	 */

--- a/src/com/palmergames/bukkit/TownyChat/listener/TownyChatPlayerListener.java
+++ b/src/com/palmergames/bukkit/TownyChat/listener/TownyChatPlayerListener.java
@@ -63,9 +63,39 @@ public class TownyChatPlayerListener implements Listener  {
 	private void refreshPlayerChannels(Player player) {
 		plugin.getChannelsHandler().getAllChannels().values().stream().forEach(channel -> channel.forgetPlayer(player));
 	}
-	
+
+	@EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
+	public void onLowestPlayerChat(AsyncPlayerChatEvent event) {
+		if (ChatSettings.getChatListenerPriority().equalsIgnoreCase("lowest"))
+			handleChatEvent(event);
+	}
+
+	@EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
+	public void onLowPlayerChat(AsyncPlayerChatEvent event) {
+		if (ChatSettings.getChatListenerPriority().equalsIgnoreCase("low"))
+			handleChatEvent(event);
+	}
+
 	@EventHandler(ignoreCancelled = true)
-	public void onPlayerChat(AsyncPlayerChatEvent event) {
+	public void onNormalPlayerChat(AsyncPlayerChatEvent event) {
+		if (ChatSettings.getChatListenerPriority().equalsIgnoreCase("normal"))
+			handleChatEvent(event);
+	}
+
+	@EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
+	public void onHighPlayerChat(AsyncPlayerChatEvent event) {
+		if (ChatSettings.getChatListenerPriority().equalsIgnoreCase("high"))
+			handleChatEvent(event);
+	}
+
+	
+	@EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+	public void onHighestPlayerChat(AsyncPlayerChatEvent event) {
+		if (ChatSettings.getChatListenerPriority().equalsIgnoreCase("highest"))
+			handleChatEvent(event);
+	}
+
+	private void handleChatEvent(AsyncPlayerChatEvent event) {
 		Player player = event.getPlayer();
 
 		// Check if the message contains colour codes we need to remove or parse.


### PR DESCRIPTION
  - Bump min Towny version to 0.100.3.0.
  - Add the ability to choose which EventPriority TownyChat uses to modify chat.
    - Closes https://github.com/TownyAdvanced/Towny/issues/7625.
  - New ChatConfig.yml Option: modify_chat.listener_priority
    - Default: normal
    - The priority used for the AsyncPlayerChatEvent listener in TownyChat. This option will decide when TownyChat listens to the Chat event thrown by Bukkit-based servers.
    - Valid settings are: lowest, low, normal, high, highest
    - Lowest is the earliest listener, allowing TownyChat to act upon chat before Low, Normal, High, and Highest priority plugins.
    - Highest will cause TownyChat to change chat after other plugins operating on lower priorities.
    - If you don't know what any of this means leave it at normal.