### PR TITLE
Fix speak and listen channel nodes not working.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.palmergames.bukkit</groupId>
     <artifactId>TownyChat</artifactId>
     <packaging>jar</packaging>
-    <version>0.117</version>
+    <version>0.118</version>
 
     <licenses>
         <license>

--- a/src/com/palmergames/bukkit/TownyChat/channels/Channel.java
+++ b/src/com/palmergames/bukkit/TownyChat/channels/Channel.java
@@ -497,13 +497,13 @@ public abstract class Channel {
 
 	public boolean hasSpeakPermission(Player player) {
 		if (!hasSpeakPermission())
-			return hasPermission(player);
+			return true;
 		return TownyUniverse.getInstance().getPermissionSource().testPermission(player, getSpeakPermissionNode());
 	}
 
 	public boolean hasListenPermission(Player player) {
 		if (!hasListenPermission())
-			return hasPermission(player);
+			return true;
 		return TownyUniverse.getInstance().getPermissionSource().testPermission(player, getListenPermissionNode());
 	}
 }

--- a/src/com/palmergames/bukkit/TownyChat/listener/TownyChatPlayerListener.java
+++ b/src/com/palmergames/bukkit/TownyChat/listener/TownyChatPlayerListener.java
@@ -155,6 +155,13 @@ public class TownyChatPlayerListener implements Listener  {
 		 * We found no channels available so modify the chat (if enabled) and exit.
 		 */
 		if (ChatSettings.isModify_chat()) {
+			Channel channel = plugin.getChannelsHandler().getDefaultChannel();
+			if (channel.hasSpeakPermission() && !channel.hasSpeakPermission(player)) {
+				event.setCancelled(true);
+				TownyMessaging.sendMessage(player, ChatSettings.getUsingAloneMessageString());
+				return;
+			}
+			
 			Resident resident = TownyAPI.getInstance().getResident(player);
 			if (resident == null)
 				return;


### PR DESCRIPTION
Channels with speak and listen nodes were falling back to the normal channel permission node.

Also prevent players that end up in the final channel limbo also need to be able to speak in the default channel.