### PR TITLE
Port to Paper (for 0.101.3.0 || 0.102.0.0)

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,97 @@
+## [Creative Commons Attribution-NonCommercial-NoDerivs 3.0 Unported (CC BY-NC-ND 3.0)](https://creativecommons.org/licenses/by-nc-nd/3.0/)
+
+### License
+
+THE WORK (AS DEFINED BELOW) IS PROVIDED UNDER THE TERMS OF THIS CREATIVE COMMONS PUBLIC LICENSE ("CCPL" OR "LICENSE"). THE WORK IS PROTECTED BY COPYRIGHT AND/OR OTHER APPLICABLE LAW. ANY USE OF THE WORK OTHER THAN AS AUTHORIZED UNDER THIS LICENSE OR COPYRIGHT LAW IS PROHIBITED.
+
+BY EXERCISING ANY RIGHTS TO THE WORK PROVIDED HERE, YOU ACCEPT AND AGREE TO BE BOUND BY THE TERMS OF THIS LICENSE. TO THE EXTENT THIS LICENSE MAY BE CONSIDERED TO BE A CONTRACT, THE LICENSOR GRANTS YOU THE RIGHTS CONTAINED HERE IN CONSIDERATION OF YOUR ACCEPTANCE OF SUCH TERMS AND CONDITIONS.
+
+**1. Definitions**
+
+<ol type="a">
+<li><b>"Adaptation"</b> means a work based upon the Work, or upon the Work and other pre-existing works, such as a translation, adaptation, derivative work, arrangement of music or other alterations of a literary or artistic work, or phonogram or performance and includes cinematographic adaptations or any other form in which the Work may be recast, transformed, or adapted including in any form recognizably derived from the original, except that a work that constitutes a Collection will not be considered an Adaptation for the purpose of this License. For the avoidance of doubt, where the Work is a musical work, performance or phonogram, the synchronization of the Work in timed-relation with a moving image ("synching") will be considered an Adaptation for the purpose of this License.
+
+<li><b>"Collection"</b> means a collection of literary or artistic works, such as encyclopedias and anthologies, or performances, phonograms or broadcasts, or other works or subject matter other than works listed in Section 1(f) below, which, by reason of the selection and arrangement of their contents, constitute intellectual creations, in which the Work is included in its entirety in unmodified form along with one or more other contributions, each constituting separate and independent works in themselves, which together are assembled into a collective whole. A work that constitutes a Collection will not be considered an Adaptation (as defined above) for the purposes of this License.
+
+<li><b>"Distribute"</b> means to make available to the public the original and copies of the Work through sale or other transfer of ownership.
+
+<li><b>"Licensor"</b> means the individual, individuals, entity or entities that offer(s) the Work under the terms of this License.
+
+<li><b>"Original Author"</b> means, in the case of a literary or artistic work, the individual, individuals, entity or entities who created the Work or if no individual or entity can be identified, the publisher; and in addition (i) in the case of a performance the actors, singers, musicians, dancers, and other persons who act, sing, deliver, declaim, play in, interpret or otherwise perform literary or artistic works or expressions of folklore; (ii) in the case of a phonogram the producer being the person or legal entity who first fixes the sounds of a performance or other sounds; and, (iii) in the case of broadcasts, the organization that transmits the broadcast.
+
+<li><b>"Work"</b> means the literary and/or artistic work offered under the terms of this License including without limitation any production in the literary, scientific and artistic domain, whatever may be the mode or form of its expression including digital form, such as a book, pamphlet and other writing; a lecture, address, sermon or other work of the same nature; a dramatic or dramatico-musical work; a choreographic work or entertainment in dumb show; a musical composition with or without words; a cinematographic work to which are assimilated works expressed by a process analogous to cinematography; a work of drawing, painting, architecture, sculpture, engraving or lithography; a photographic work to which are assimilated works expressed by a process analogous to photography; a work of applied art; an illustration, map, plan, sketch or three-dimensional work relative to geography, topography, architecture or science; a performance; a broadcast; a phonogram; a compilation of data to the extent it is protected as a copyrightable work; or a work performed by a variety or circus performer to the extent it is not otherwise considered a literary or artistic work.
+
+<li><b>"You"</b> means an individual or entity exercising rights under this License who has not previously violated the terms of this License with respect to the Work, or who has received express permission from the Licensor to exercise rights under this License despite a previous violation.
+
+<li><b>"Publicly Perform"</b> means to perform public recitations of the Work and to communicate to the public those public recitations, by any means or process, including by wire or wireless means or public digital performances; to make available to the public Works in such a way that members of the public may access these Works from a place and at a place individually chosen by them; to perform the Work to the public by any means or process and the communication to the public of the performances of the Work, including by public digital performance; to broadcast and rebroadcast the Work by any means including signs, sounds or images.
+
+<li><b>"Reproduce"</b> means to make copies of the Work by any means including without limitation by sound or visual recordings and the right of fixation and reproducing fixations of the Work, including storage of a protected performance or phonogram in digital form or other electronic medium.
+</ol>
+
+**2. Fair Dealing Rights.** Nothing in this License is intended to reduce, limit, or restrict any uses free from copyright or rights arising from limitations or exceptions that are provided for in connection with the copyright protection under copyright law or other applicable laws.
+
+**3. License Grant.** Subject to the terms and conditions of this License, Licensor hereby grants You a worldwide, royalty-free, non-exclusive, perpetual (for the duration of the applicable copyright) license to exercise the rights in the Work as stated below:
+
+<ol type="a">
+<li>to Reproduce the Work, to incorporate the Work into one or more Collections, and to Reproduce the Work as incorporated in the Collections; and,
+<li>to Distribute and Publicly Perform the Work including as incorporated in Collections.
+</ol>
+
+The above rights may be exercised in all media and formats whether now known or hereafter devised. The above rights include the right to make such modifications as are technically necessary to exercise the rights in other media and formats, but otherwise you have no rights to make Adaptations. Subject to 8(f), all rights not expressly granted by Licensor are hereby reserved, including but not limited to the rights set forth in Section 4(d).
+
+**4. Restrictions.** The license granted in Section 3 above is expressly made subject to and limited by the following restrictions:
+
+<ol type="a">
+
+<li>You may Distribute or Publicly Perform the Work only under the terms of this License. You must include a copy of, or the Uniform Resource Identifier (URI) for, this License with every copy of the Work You Distribute or Publicly Perform. You may not offer or impose any terms on the Work that restrict the terms of this License or the ability of the recipient of the Work to exercise the rights granted to that recipient under the terms of the License. You may not sublicense the Work. You must keep intact all notices that refer to this License and to the disclaimer of warranties with every copy of the Work You Distribute or Publicly Perform. When You Distribute or Publicly Perform the Work, You may not impose any effective technological measures on the Work that restrict the ability of a recipient of the Work from You to exercise the rights granted to that recipient under the terms of the License. This Section 4(a) applies to the Work as incorporated in a Collection, but this does not require the Collection apart from the Work itself to be made subject to the terms of this License. If You create a Collection, upon notice from any Licensor You must, to the extent practicable, remove from the Collection any credit as required by Section 4(c), as requested.
+
+<li>You may not exercise any of the rights granted to You in Section 3 above in any manner that is primarily intended for or directed toward commercial advantage or private monetary compensation. The exchange of the Work for other copyrighted works by means of digital file-sharing or otherwise shall not be considered to be intended for or directed toward commercial advantage or private monetary compensation, provided there is no payment of any monetary compensation in connection with the exchange of copyrighted works.
+
+<li>If You Distribute, or Publicly Perform the Work or Collections, You must, unless a request has been made pursuant to Section 4(a), keep intact all copyright notices for the Work and provide, reasonable to the medium or means You are utilizing: (i) the name of the Original Author (or pseudonym, if applicable) if supplied, and/or if the Original Author and/or Licensor designate another party or parties (e.g., a sponsor institute, publishing entity, journal) for attribution ("Attribution Parties") in Licensor's copyright notice, terms of service or by other reasonable means, the name of such party or parties; (ii) the title of the Work if supplied; (iii) to the extent reasonably practicable, the URI, if any, that Licensor specifies to be associated with the Work, unless such URI does not refer to the copyright notice or licensing information for the Work. The credit required by this Section 4(c) may be implemented in any reasonable manner; provided, however, that in the case of a Collection, at a minimum such credit will appear, if a credit for all contributing authors of Collection appears, then as part of these credits and in a manner at least as prominent as the credits for the other contributing authors. For the avoidance of doubt, You may only use the credit required by this Section for the purpose of attribution in the manner set out above and, by exercising Your rights under this License, You may not implicitly or explicitly assert or imply any connection with, sponsorship or endorsement by the Original Author, Licensor and/or Attribution Parties, as appropriate, of You or Your use of the Work, without the separate, express prior written permission of the Original Author, Licensor and/or Attribution Parties.
+
+<li>For the avoidance of doubt:
+<ol type="i">
+<li><b>Non-waivable Compulsory License Schemes.</b> In those jurisdictions in which the right to collect royalties through any statutory or compulsory licensing scheme cannot be waived, the Licensor reserves the exclusive right to collect such royalties for any exercise by You of the rights granted under this License;
+
+<li><b>Waivable Compulsory License Schemes.</b> In those jurisdictions in which the right to collect royalties through any statutory or compulsory licensing scheme can be waived, the Licensor reserves the exclusive right to collect such royalties for any exercise by You of the rights granted under this License if Your exercise of such rights is for a purpose or use which is otherwise than noncommercial as permitted under Section 4(b) and otherwise waives the right to collect royalties through any statutory or compulsory licensing scheme; and,
+
+<li><b>Voluntary License Schemes.</b> The Licensor reserves the right to collect royalties, whether individually or, in the event that the Licensor is a member of a collecting society that administers voluntary licensing schemes, via that society, from any exercise by You of the rights granted under this License that is for a purpose or use which is otherwise than noncommercial as permitted under Section 4(b).
+</ol>
+
+<li>Except as otherwise agreed in writing by the Licensor or as may be otherwise permitted by applicable law, if You Reproduce, Distribute or Publicly Perform the Work either by itself or as part of any Collections, You must not distort, mutilate, modify or take other derogatory action in relation to the Work which would be prejudicial to the Original Author's honor or reputation.
+</ol>
+
+**5. Representations, Warranties and Disclaimer**
+
+UNLESS OTHERWISE MUTUALLY AGREED BY THE PARTIES IN WRITING, LICENSOR OFFERS THE WORK AS-IS AND MAKES NO REPRESENTATIONS OR WARRANTIES OF ANY KIND CONCERNING THE WORK, EXPRESS, IMPLIED, STATUTORY OR OTHERWISE, INCLUDING, WITHOUT LIMITATION, WARRANTIES OF TITLE, MERCHANTIBILITY, FITNESS FOR A PARTICULAR PURPOSE, NONINFRINGEMENT, OR THE ABSENCE OF LATENT OR OTHER DEFECTS, ACCURACY, OR THE PRESENCE OF ABSENCE OF ERRORS, WHETHER OR NOT DISCOVERABLE. SOME JURISDICTIONS DO NOT ALLOW THE EXCLUSION OF IMPLIED WARRANTIES, SO SUCH EXCLUSION MAY NOT APPLY TO YOU.
+
+**6. Limitation on Liability.** EXCEPT TO THE EXTENT REQUIRED BY APPLICABLE LAW, IN NO EVENT WILL LICENSOR BE LIABLE TO YOU ON ANY LEGAL THEORY FOR ANY SPECIAL, INCIDENTAL, CONSEQUENTIAL, PUNITIVE OR EXEMPLARY DAMAGES ARISING OUT OF THIS LICENSE OR THE USE OF THE WORK, EVEN IF LICENSOR HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+
+**7. Termination**
+
+<ol type="a">
+<li>This License and the rights granted hereunder will terminate automatically upon any breach by You of the terms of this License. Individuals or entities who have received Collections from You under this License, however, will not have their licenses terminated provided such individuals or entities remain in full compliance with those licenses. Sections 1, 2, 5, 6, 7, and 8 will survive any termination of this License.
+
+<li>Subject to the above terms and conditions, the license granted here is perpetual (for the duration of the applicable copyright in the Work). Notwithstanding the above, Licensor reserves the right to release the Work under different license terms or to stop distributing the Work at any time; provided, however that any such election will not serve to withdraw this License (or any other license that has been, or is required to be, granted under the terms of this License), and this License will continue in full force and effect unless terminated as stated above.
+</ol>
+
+**8. Miscellaneous**
+
+<ol type="a">
+<li>Each time You Distribute or Publicly Perform the Work or a Collection, the Licensor offers to the recipient a license to the Work on the same terms and conditions as the license granted to You under this License.
+
+<li>If any provision of this License is invalid or unenforceable under applicable law, it shall not affect the validity or enforceability of the remainder of the terms of this License, and without further action by the parties to this agreement, such provision shall be reformed to the minimum extent necessary to make such provision valid and enforceable.
+
+<li>No term or provision of this License shall be deemed waived and no breach consented to unless such waiver or consent shall be in writing and signed by the party to be charged with such waiver or consent.
+
+<li>This License constitutes the entire agreement between the parties with respect to the Work licensed here. There are no understandings, agreements or representations with respect to the Work not specified here. Licensor shall not be bound by any additional provisions that may appear in any communication from You. This License may not be modified without the mutual written agreement of the Licensor and You.
+
+<li>The rights granted under, and the subject matter referenced, in this License were drafted utilizing the terminology of the Berne Convention for the Protection of Literary and Artistic Works (as amended on September 28, 1979), the Rome Convention of 1961, the WIPO Copyright Treaty of 1996, the WIPO Performances and Phonograms Treaty of 1996 and the Universal Copyright Convention (as revised on July 24, 1971). These rights and subject matter take effect in the relevant jurisdiction in which the License terms are sought to be enforced according to the corresponding provisions of the implementation of those treaty provisions in the applicable national law. If the standard suite of rights granted under applicable copyright law includes additional rights not granted under this License, such additional rights are deemed to be included in the License; this License is not intended to restrict the license of any rights under applicable law.
+</ol>
+
+> #### Creative Commons Notice
+>Creative Commons is not a party to this License, and makes no warranty whatsoever in connection with the Work. Creative Commons will not be liable to You or any party on any legal theory for any damages whatsoever, including without limitation any general, special, incidental or consequential damages arising in connection to this license. Notwithstanding the foregoing two (2) sentences, if Creative Commons has expressly identified itself as the Licensor hereunder, it shall have all rights and obligations of Licensor.
+>
+>Except for the limited purpose of indicating to the public that the Work is licensed under the CCPL, Creative Commons does not authorize the use by either party of the trademark "Creative Commons" or any related trademark or logo of Creative Commons without the prior written consent of Creative Commons. Any permitted use will be in compliance with Creative Commons' then-current trademark usage guidelines, as may be published on its website or otherwise made available upon request from time to time. For the avoidance of doubt, this trademark restriction does not form part of this License.
+>
+> Creative Commons may be contacted at [https://creativecommons.org/](https://creativecommons.org/).

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ ___
 > Prior versions of TownyChat may continue to function, but are unsupported if not used as advertised.
 
 * **[Current Development](https://github.com/TownyAdvanced/TownyChat) \[Future 0.120\]**
-  * Supports Towny 0.101.2.1+ (Pre-Release)
+  * Supports Towny 0.102.0.0+
 
 * **[Current Release](https://github.com/TownyAdvanced/TownyChat/releases/0.119) \[0.119\]**
   * Supports Towny 0.100.4.0 &ndash; 0.101.2.0 (Release)

--- a/README.md
+++ b/README.md
@@ -175,8 +175,6 @@ ___
 
 ### Building TownyChat
 If you would like to build TownyChat yourself, you can do so with [Apache Maven](https://maven.apache.org/).
-Depending on the age of the branch, you may wish to instead look at [Apache Ant](https://ant.apache.org).
-Building with Ant is outside of this brief tutorial's scope.
 
 #### Steps
 > Steps 2 &ndash; 4 can be managed by an IDE, such as IntelliJ Idea or Eclipse.<br>

--- a/README.md
+++ b/README.md
@@ -1,0 +1,192 @@
+# TownyChat
+## A component of [Towny Advanced](https://townyadvanced.github.io)
+
+___
+
+> Hello Towny community,
+>
+> To the folks already sponsoring me: you are all awesome, the words below do not apply to you.
+> I am grateful for the help you've provided me over the years (some of you, you know who you are), and I am incredibly grateful for the support you've given.
+>
+> I have been working with Towny since 2011. I have been in charge of the project since 2014.
+> I have put in more than 13 years of service to an Open Source project that you use.
+> I have not run a minecraft server, or played minecraft in over 7 years.
+> 
+> Some of you may know this, some may not: In 2021 my IRL work was up-ended, resulting in a major reset of my career.
+> The result was that I have not been bringing in the same income as I was before, something I require to feed, cloth and house my wife and young children.
+> Up until that point, my normal job fully-subsidized the time I put into coding Towny and its many add-on plugin.
+> You all have enjoyed my works because I was able to feed and house my family via my regular work whilst paying myself to work on Towny.
+> 
+> I make myself available regularly on Discord answering mundane and complex questions alike.
+> Bugs are usually fixed the same day they are reported.
+> Other developers that contribute Pull Requests to Towny get reviews right away, and jr developers can usually expect me to help with commits so their work gets merged.
+>
+> 99% of Towny server admins are not sponsoring the work that I put into Towny.
+> The truth about well-managed open source projects is that the developers of them need to be compensated for the time and energy they put into their software.
+> Developers of large projects are unfortunately rarely compensated, and in fact receive a lot of push back from people who expect free software at no cost.
+>
+> There are days that I enjoy every minute of what I do with Towny.
+> Helping out the new server admins with their greenleaf in the Discord as they learn the ropes around Towny can be fun.
+> Making a sponsor's feature request a reality.
+> Creating a brand-new add-on plugin from nothing but code and the TownyAPI that I have spent years fostering.
+> As of this posting Towny has a 4.7/5 rating on Spigot, with 145 reviews. Nearly all of these reviews cite me and my efforts.
+> I enjoy coding, or I would not still be doing it.
+>
+> And then there are days that I do not enjoy every minute of it,
+> but you will not find any days that I have not answered every question asked on the Discord by new admins or sponsors.
+>
+> I not only provide server owners with amazing support I also provide many plugins.
+> It is not uncommon for servers to use Towny with side-plugins I am also in charge of:
+> SiegeWar, Dynmap-Towny, iConomy5, TownyResources, TownyProvinces all playing very large roles on the server with other plugins like TownyChat, TownyFlight, TownyCultures, and others playing smaller roles.
+> I read people's startup logs when they need my help, and they tend to use a lot of my plugins if they use Towny.
+>
+> I remember the time that Goosius decided to stop working on his fork of Towny that had SiegeWar built into it.
+> He spent a little more than a year doing intense, active development, constantly getting feedback from server admins and players,
+> constantly tweaking things. And then he vanished, burnt out from everything.
+> He logged out of his SiegeWar discord and that was seemingly it.
+> When I joined the SiegeWar discord in late 2020, I was surprised at how many people were clamouring for SiegeWar,
+> willing to throw money at anyone that would continue coding SiegeWar.
+> The developer left, and all of a sudden people were willing to pay.
+> I have pulled SiegeWar from the ashes twice now, and yet the greater reward is not there.
+>
+> As of the start of 2024 I have enacted a new policy:
+>
+> > If you're expecting support on the Discord: I expect you to sponsor. Companies that provide software do not provide support for free.
+> I will probably still respond to you if you're brand new and need that extra bit of help. If you can find something that isn't already documented on the Wiki, let me know and I'll add it.
+> 
+> > If you are not sponsoring, please do not make suggestions for new features, I don't need ideas right now.
+>
+> This is due to underfunding, if sponsorships rise to a level at which I can sustain myself and my family the time I can devote to Towny will expand and the support floodgates will re-open. My time coding is being devoted to the people who are giving back by sponsoring me.
+>
+> Thank you for reading,<br>
+> &mdash; LlmDl
+
+
+
+___
+
+<p><img align=right src="https://user-images.githubusercontent.com/879756/65964696-19d6b300-e423-11e9-9cb0-d193225ee40f.png">
+
+TownyChat is the reference chat implementation for [Towny](https://github.com/TownyAdvanced/Towny),
+providing channels for Towns, Nations, and Alliances. It is currently maintained by [LlmDl](https://github.com/LlmDl),
+having taken over for [ElgarL](https://github.com/ElgarL) in 2014.
+
+Development of TownyChat is primarily undertaken by the core members of TownyAdvanced, but is open to contributions.
+TownyChat has had many [Contributors](https://github.com/TownyAdvanced/TownyChat/graphs/contributors) who have helped improve it over the years.
+
+> **If you're interested in other add-on plugins for Towny, [check out the TownyAdvanced Portal](https://townyadvanced.github.io).
+> <br><br>
+> There you can view and download most of the plugins that the team maintains.
+> <br>
+> Or, check out the [SponsorPlugins](https://github.com/LlmDl/SponsorPlugins#readme) you get access to when you give back!**
+
+<!-- TODO - Set this up, then enable it. -->
+<!--[![CodeFactor](https://www.codefactor.io/repository/github/townyadvanced/townychat/badge)](https://www.codefactor.io/repository/github/townyadvanced/townychat)-->
+___
+
+### Current Recommended Versions
+
+> TownyAdvanced only offers support for the latest release of TownyChat, when paired with an appropriate Towny version.
+> Prior versions of TownyChat may continue to function, but are unsupported if not used as advertised.
+
+* **[Current Development](https://github.com/TownyAdvanced/TownyChat) \[Future 0.120\]**
+  * Supports Towny 0.101.2.1+ (Pre-Release)
+
+* **[Current Release](https://github.com/TownyAdvanced/TownyChat/releases/0.119) \[0.119\]**
+  * Supports Towny 0.100.4.0 &ndash; 0.101.2.0 (Release)
+
+* **Previous Versions**
+  * Check the [Release Pages](https://github.com/TownyAdvanced/TownyChat/releases)
+___
+
+### Staying up to date
+<p><img align=right src="https://user-images.githubusercontent.com/879756/65964779-3a067200-e423-11e9-9928-938b976af2c2.gif" height="155">
+
+All Release builds are being made available here on GitHub's [Releases](https://github.com/TownyAdvanced/TownyChat/releases) tab.
+I am recommending that server admins "watch" TownyChat on github for updates.
+Just click the watch button in the upper right and select "`Custom` > `Releases`".
+
+> TownyChat is also released alongside Towny, and is bundled with official releases.<br>
+> You can set up alerts on [Hanger](https://hangar.papermc.io/TownyAdvanced/Towny),
+> or watch [Towny](https://github.com/TownyAdvanced/Towny) here on GitHub.
+</p>
+
+Missed a few versions? You can also check out the [ChangeLog](https://github.com/TownyAdvanced/TownyChat/blob/master/resources/changelog.txt).
+
+___
+
+### Connect/Support
+The documentation found on the [Towny Wiki](https://github.com/TownyAdvanced/Towny/wiki) is updated every time a Release version of Towny is put out.
+For important changes since the previous Release build, we recommend reading TownyChat's release pages.
+
+Some important pages to look over:
+- **[ChatConfig](https://github.com/TownyAdvanced/Towny/wiki/Default-ChatConfig.yml)** - TownyChat Default Chat Configuration
+- **[Channels](https://github.com/TownyAdvanced/Towny/wiki/Default-Channels.yml)** - Channel Configuration
+
+On Towny's GitHub [Issue Tracker](https://github.com/TownyAdvanced/Towny/issues) you can file [bug reports](https://github.com/TownyAdvanced/Towny/issues/new?assignees=&labels=&template=bug_report.md&title=),
+[feature requests](https://github.com/TownyAdvanced/Towny/issues/new?assignees=&labels=&template=feature_request.md&title=Suggestion%3A+),
+or just ask [general questions.](https://github.com/TownyAdvanced/Towny/discussions/new?category=Q-A)
+
+[![Average time to resolve an issue](https://isitmaintained.com/badge/resolution/TownyAdvanced/Towny.svg)](https://isitmaintained.com/project/TownyAdvanced/Towny "Average time to resolve an issue") [![Percentage of issues still open](https://isitmaintained.com/badge/open/TownyAdvanced/Towny.svg)](https://isitmaintained.com/project/TownyAdvanced/Towny "Percentage of issues still open")
+
+If you still need help, join us on the [Discord server]( https://discord.gg/gnpVs5m ), where you'll find Channels for support,
+add-on plugins, [SponsorPlugins](https://github.com/LlmDl/SponsorPlugins#readme), discuss plugin-development and just regular old discussion of the plugin.
+
+**Note: If you are not a new Towny admin, it is expected that you [become a Sponsor](https://github.com/sponsors/LlmDl) if you want hands on support from LlmDl.**
+
+___
+
+### Contributing
+If you'd like to contribute to the Towny code, see the [CONTRIBUTING.md](https://github.com/LlmDl/Towny/blob/master/.github/CONTRIBUTING.MD) over on Towny.
+
+___
+
+### Translations
+
+TownyChat does not offer its own localization. Instead, this is partially handled within Towny.
+
+If you'd like to help translating Towny into the available languages or add entirely new languages, [we're on Crowdin!](https://crowdin.com/project/townyadvanced)
+
+[![Crowdin](https://badges.crowdin.net/townyadvanced/localized.svg)](https://crowdin.com/project/townyadvanced)
+
+___
+
+### Licensing
+Towny & TownyChat are licensed under the [Creative Commons Attribution-NonCommercial-NoDerivs 3.0 Unported (CC BY-NC-ND 3.0) License ](https://creativecommons.org/licenses/by-nc-nd/3.0/)
+You can view a repo-local copy of this license at [LICENSE.md](./LICENSE.md).
+
+We don't object to you making your own personal-use forks and builds, but we do object to people being selfish, which is why we specify No Derivative Works.
+If you want to modify the code to add a nice feature or two, the least you can do is ask and submit a Pull Request to allow everyone to benefit from it.
+
+___
+
+### Hooking directly with TownyChat
+[![](https://jitpack.io/v/TownyAdvanced/TownyChat.svg)](https://jitpack.io/#TownyAdvanced/TownyChat)
+
+You can hook directly into TownyChat, if you wish. This is however, unsupported.
+Builds of TownyChat are not currently published to the Towny repository hosted at https://repo.glaremasters.me/repository/towny/.
+You will need to grab it from Jitpack, or install it to your local Maven repository.
+
+We encourage developers who wish to use the Towny API in their plugins to read
+[the following instructions on adding Towny via a Maven pom.xml,](https://github.com/TownyAdvanced/Towny/wiki/TownyAPI#getting-started-with-towny-and-your-ide)
+or read [the API guide](https://github.com/TownyAdvanced/Towny/wiki/TownyAPI) to learn about the vast API Towny has to offer.
+
+___
+
+### Building TownyChat
+If you would like to build TownyChat yourself, you can do so with [Apache Maven](https://maven.apache.org/).
+Depending on the age of the branch, you may wish to instead look at [Apache Ant](https://ant.apache.org).
+Building with Ant is outside of this brief tutorial's scope.
+
+#### Steps
+> Steps 2 &ndash; 4 can be managed by an IDE, such as IntelliJ Idea or Eclipse.<br>
+> If cloning with an IDE, please refer to your IDE's documentation.
+
+1. Satisfy prerequisites (Maven, JDK 17+, Git, etc.)
+2. (Optional) Fork the repository to your own GitHub account.
+3. Clone Repository (`git clone https://github.com/TownyAdvanced/TownyChat.git`)
+   * If you forked: Replace `TownyAdvanced` with your GitHub Username in the command above.
+4. Open the locally cloned `TownyChat` directory in a terminal shell, or Windows Command Prompt.
+5. Run `mvn clean package`
+   * Maven will generate the plugin inside the `TownyChat/target/` directory.
+6. Copy the JAR file to a server for testing.

--- a/pom.xml
+++ b/pom.xml
@@ -80,28 +80,6 @@
             <groupId>io.papermc.paper</groupId>
             <artifactId>paper-api</artifactId>
             <version>1.19.4-R0.1-SNAPSHOT</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.google.guava</groupId>
-                    <artifactId>guava</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.yaml</groupId>
-                    <artifactId>snakeyaml</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>net.kyori</groupId>
-                    <artifactId>adventure-text-serializer-gson</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.maven</groupId>
-                    <artifactId>maven-resolver-provider</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>net.md-5</groupId>
-                    <artifactId>bungeecord-chat</artifactId>
-                </exclusion>
-            </exclusions>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -109,20 +87,6 @@
             <artifactId>EssentialsX</artifactId>
             <version>${essentialsx.version}</version>
             <scope>provided</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.bstats</groupId>
-                    <artifactId>bstats-bukkit</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>net.kyori</groupId>
-                    <artifactId>adventure-text-serializer-gson</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.commons</groupId>
-                    <artifactId>commons-lang3</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>us.dynmap</groupId>
@@ -149,20 +113,8 @@
             <scope>provided</scope>
             <exclusions>
                 <exclusion>
-                    <groupId>net.dv8tion</groupId>
-                    <artifactId>JDA</artifactId>
-                </exclusion>
-                <exclusion>
                     <groupId>com.github.MinnDevelopment</groupId>
                     <artifactId>emoji-java</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>club.minnced</groupId>
-                    <artifactId>discord-webhooks</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.commons</groupId>
-                    <artifactId>commons-lang3</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <licenses>
         <license>
             <name>CC BY-NC-ND 3.0</name>
-            <url>http://creativecommons.org/licenses/by-nc-nd/3.0/</url>
+            <url>https://creativecommons.org/licenses/by-nc-nd/3.0/</url>
             <comments>Creative Commons Attribution-NonCommercial-NoDerivs 3.0 Unported</comments>
         </license>
     </licenses>
@@ -23,12 +23,12 @@
     </organization>
 
     <properties>
-        <java.version>17</java.version>
-        <project.bukkitAPIVersion>1.19</project.bukkitAPIVersion>
+        <java.version>21</java.version>
+        <project.bukkitAPIVersion>1.21</project.bukkitAPIVersion>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <towny.version>0.101.2.1</towny.version>
+        <towny.version>0.102.0.0</towny.version>
         <essentialsx.version>2.21.2</essentialsx.version>
-        <dynmap.version>3.6</dynmap.version>
+        <dynmap.version>3.8</dynmap.version>
     </properties>
 
     <!-- For use with GitHub Package Registry -->
@@ -79,7 +79,7 @@
         <dependency>
             <groupId>io.papermc.paper</groupId>
             <artifactId>paper-api</artifactId>
-            <version>1.19.4-R0.1-SNAPSHOT</version>
+            <version>1.21.1-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -103,7 +103,7 @@
         <dependency>
             <groupId>me.clip</groupId>
             <artifactId>placeholderapi</artifactId>
-            <version>2.11.6</version>
+            <version>2.11.7</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -23,8 +23,8 @@
     </organization>
 
     <properties>
-        <java.version>21</java.version>
-        <project.bukkitAPIVersion>1.21</project.bukkitAPIVersion>
+        <java.version>17</java.version>
+        <project.bukkitAPIVersion>1.19</project.bukkitAPIVersion>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <towny.version>0.102.0.0</towny.version>
         <essentialsx.version>2.21.2</essentialsx.version>

--- a/pom.xml
+++ b/pom.xml
@@ -146,6 +146,7 @@
             <groupId>net.essentialsx</groupId>
             <artifactId>EssentialsXDiscord</artifactId>
             <version>${essentialsx.version}</version>
+            <scope>provided</scope>
             <exclusions>
                 <exclusion>
                     <groupId>net.dv8tion</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.palmergames.bukkit</groupId>
     <artifactId>TownyChat</artifactId>
     <packaging>jar</packaging>
-    <version>0.119</version>
+    <version>0.120-SNAPSHOT</version>
 
     <licenses>
         <license>
@@ -24,9 +24,11 @@
 
     <properties>
         <java.version>17</java.version>
-        <project.bukkitAPIVersion>1.16</project.bukkitAPIVersion>
+        <project.bukkitAPIVersion>1.19</project.bukkitAPIVersion>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <towny.version>0.100.4.0</towny.version>
+        <towny.version>0.101.2.1</towny.version>
+        <essentialsx.version>2.21.2</essentialsx.version>
+        <dynmap.version>3.6</dynmap.version>
     </properties>
 
     <!-- For use with GitHub Package Registry -->
@@ -36,7 +38,7 @@
             <name>GitHub TownyAdvanced Apache Maven Packages</name>
             <url>https://maven.pkg.github.com/TownyAdvanced</url>
         </repository>
-    </distributionManagement> 
+    </distributionManagement>
 
     <scm>
         <connection>scm:git:https://github.com/TownyAdvanced/TownyChat.git</connection>
@@ -45,10 +47,6 @@
     </scm>
 
     <repositories>
-        <repository>
-            <id>spigot-repo</id>
-            <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
-        </repository>
         <repository>
             <id>papermc</id>
             <url>https://repo.papermc.io/repository/maven-public/</url>
@@ -62,16 +60,12 @@
             <url>https://repo.mikeprimm.com</url>
         </repository>
         <repository>
-            <id>glaremasters repo</id>
+            <id>glaremasters-repo</id>
             <url>https://repo.glaremasters.me/repository/towny/</url>
         </repository>
         <repository>
             <id>placeholderapi</id>
             <url>https://repo.extendedclip.com/content/repositories/placeholderapi/</url>
-        </repository>
-        <repository>
-            <id>jitpack.io</id>
-            <url>https://jitpack.io</url>
         </repository>
     </repositories>
 
@@ -83,56 +77,98 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.spigotmc</groupId>
-            <artifactId>spigot-api</artifactId>
-            <version>1.20.2-R0.1-SNAPSHOT</version>
+            <groupId>io.papermc.paper</groupId>
+            <artifactId>paper-api</artifactId>
+            <version>1.19.4-R0.1-SNAPSHOT</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.yaml</groupId>
+                    <artifactId>snakeyaml</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>net.kyori</groupId>
+                    <artifactId>adventure-text-serializer-gson</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.maven</groupId>
+                    <artifactId>maven-resolver-provider</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>net.md-5</groupId>
+                    <artifactId>bungeecord-chat</artifactId>
+                </exclusion>
+            </exclusions>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>net.essentialsx</groupId>
             <artifactId>EssentialsX</artifactId>
-            <version>2.19.0</version>
+            <version>${essentialsx.version}</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>
                     <groupId>org.bstats</groupId>
                     <artifactId>bstats-bukkit</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>net.kyori</groupId>
+                    <artifactId>adventure-text-serializer-gson</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-lang3</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
             <groupId>us.dynmap</groupId>
             <artifactId>dynmap-api</artifactId>
-            <version>3.0-SNAPSHOT</version>
+            <version>${dynmap.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>us.dynmap</groupId>
+            <artifactId>DynmapCoreAPI</artifactId>
+            <version>${dynmap.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>me.clip</groupId>
             <artifactId>placeholderapi</artifactId>
-            <version>2.11.5</version>
+            <version>2.11.6</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.EssentialsX.Essentials</groupId>
+            <groupId>net.essentialsx</groupId>
             <artifactId>EssentialsXDiscord</artifactId>
-            <version>57600f333c</version>
-            <scope>provided</scope>
+            <version>${essentialsx.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>net.dv8tion</groupId>
                     <artifactId>JDA</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.github.MinnDevelopment</groupId>
+                    <artifactId>emoji-java</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>club.minnced</groupId>
+                    <artifactId>discord-webhooks</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-lang3</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
         <dependency>
             <groupId>org.jetbrains</groupId>
             <artifactId>annotations</artifactId>
-            <version>16.0.2</version>
-        </dependency>
-        <dependency>
-            <groupId>com.github.bsideup.jabel</groupId>
-            <artifactId>jabel-javac-plugin</artifactId>
-            <version>1.0.0</version>
+            <version>26.0.2</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>
@@ -145,12 +181,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.11.0</version>
                 <configuration>
-                    <release>8</release>
-                    <source>${java.version}</source>
-                    <target>${java.version}</target>
-                    <compilerArgs>
-                        <arg>-Xplugin:jabel</arg>
-                    </compilerArgs>
+                    <release>${java.version}</release>
                 </configuration>
             </plugin>
         </plugins>

--- a/src/com/palmergames/bukkit/TownyChat/Chat.java
+++ b/src/com/palmergames/bukkit/TownyChat/Chat.java
@@ -60,7 +60,7 @@ public class Chat extends JavaPlugin {
 	private DynmapAPI dynMap = null;
 	private Essentials essentials = null;
 	
-	private static final String requiredTownyVersion = "0.101.2.1";
+	private static final String requiredTownyVersion = "0.102.0.0";
 	public static boolean usingPlaceholderAPI = false;
 	public static boolean usingEssentialsDiscord = false;
 	boolean chatConfigError = false;

--- a/src/com/palmergames/bukkit/TownyChat/Chat.java
+++ b/src/com/palmergames/bukkit/TownyChat/Chat.java
@@ -39,11 +39,13 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
 /**
- * Chat plugin to manage all Towny chat
- * 
- * Website: http://code.google.com/a/eclipselabs.org/p/towny/
- * 
+ * Reference Chat Plugin for Towny
+ *
+ * @link <a href="https://townyadvanced.github.io">TownyAdvanced</a>
+ * @link <a href="https://github.com/TownyAdvanced/TownyChat">Source Code (GitHub)</a>
+ * @link <a href="https://creativecommons.org/licenses/by-nc-nd/3.0/">License (CC BY-NC-ND 3.0)</a>
  * @author ElgarL
+ * @author LlmDl
  */
 
 public class Chat extends JavaPlugin {
@@ -58,7 +60,7 @@ public class Chat extends JavaPlugin {
 	private DynmapAPI dynMap = null;
 	private Essentials essentials = null;
 	
-	private static String requiredTownyVersion = "0.100.4.0";
+	private static final String requiredTownyVersion = "0.101.2.1";
 	public static boolean usingPlaceholderAPI = false;
 	public static boolean usingEssentialsDiscord = false;
 	boolean chatConfigError = false;


### PR DESCRIPTION
This PR lays the groundwork for future paper-native adaptions, given the next version of Towny is planned to only support Paper.

Spigot-API has been swapped for Paper-API 1.19.4 (This can probably be raised, playing it safe.)

Dependencies have been updated, and the JVM language level has been upgraded to Java 17. The minimum supported Towny version has been bumped to 0.101.2.1.

Also in this PR is some basic house-cleaning:
- README adapted from Towny's README
- LICENSE copied from Towny.
- Removed Jitpack and Jabel