### PR TITLE
0.120:

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.palmergames.bukkit</groupId>
     <artifactId>TownyChat</artifactId>
     <packaging>jar</packaging>
-    <version>0.119</version>
+    <version>0.120</version>
 
     <licenses>
         <license>
@@ -26,7 +26,7 @@
         <java.version>17</java.version>
         <project.bukkitAPIVersion>1.16</project.bukkitAPIVersion>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <towny.version>0.100.4.0</towny.version>
+        <towny.version>0.101.2.5</towny.version>
     </properties>
 
     <!-- For use with GitHub Package Registry -->
@@ -45,10 +45,6 @@
     </scm>
 
     <repositories>
-        <repository>
-            <id>spigot-repo</id>
-            <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
-        </repository>
         <repository>
             <id>papermc</id>
             <url>https://repo.papermc.io/repository/maven-public/</url>
@@ -77,16 +73,21 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.papermc.paper</groupId>
+            <artifactId>paper-api</artifactId>
+            <version>1.21.8-R0.1-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+<!--        <dependency>
             <groupId>com.palmergames.bukkit.towny</groupId>
             <artifactId>towny</artifactId>
             <version>${towny.version}</version>
             <scope>provided</scope>
-        </dependency>
+        </dependency>-->
         <dependency>
-            <groupId>org.spigotmc</groupId>
-            <artifactId>spigot-api</artifactId>
-            <version>1.20.2-R0.1-SNAPSHOT</version>
-            <scope>provided</scope>
+            <groupId>com.github.TownyAdvanced.Towny</groupId>
+            <artifactId>towny</artifactId>
+            <version>master-4907b3123a-1</version>
         </dependency>
         <dependency>
             <groupId>net.essentialsx</groupId>

--- a/resources/changelog.txt
+++ b/resources/changelog.txt
@@ -516,3 +516,6 @@ v0.116:
   - Fix speak and listen channel nodes not working.
 0.119:
   - Fix regression in 0.118 and channel permissions.
+0.120:
+  - Update to support Towny's adoption of Paper over Spigot.
+  - Bump min. Towny version to 0.101.2.5.

--- a/src/com/palmergames/bukkit/TownyChat/Chat.java
+++ b/src/com/palmergames/bukkit/TownyChat/Chat.java
@@ -58,7 +58,7 @@ public class Chat extends JavaPlugin {
 	private DynmapAPI dynMap = null;
 	private Essentials essentials = null;
 	
-	private static String requiredTownyVersion = "0.100.4.0";
+	private static String requiredTownyVersion = "0.101.2.5";
 	public static boolean usingPlaceholderAPI = false;
 	public static boolean usingEssentialsDiscord = false;
 	boolean chatConfigError = false;
@@ -81,7 +81,7 @@ public class Chat extends JavaPlugin {
 			disableWithMessage("Towny version does not meet required minimum version: " + requiredTownyVersion.toString());
 			return;
 		} else {
-			getLogger().info("Towny version " + towny.getDescription().getVersion() + " found.");
+			getLogger().info("Towny version " + towny.getPluginMeta().getVersion() + " found.");
 		}
 		
 		loadConfigs();

--- a/src/com/palmergames/bukkit/TownyChat/config/ChatSettings.java
+++ b/src/com/palmergames/bukkit/TownyChat/config/ChatSettings.java
@@ -54,7 +54,7 @@ public class ChatSettings {
 	 */
 	private static void setDefaults(File file) {
 
-		String version = Chat.getTownyChat().getDescription().getVersion();
+		String version = Chat.getTownyChat().getPluginMeta().getVersion();
 		newChatConfig = new CommentedConfiguration(file.toPath());
 		newChatConfig.load();
 


### PR DESCRIPTION
  - Update to support Towny's adoption of Paper over Spigot.
  - Bump min. Towny version to 0.101.2.5.